### PR TITLE
Removing docker dependency since macos needs the cask version

### DIFF
--- a/Formula/scwrypts.rb
+++ b/Formula/scwrypts.rb
@@ -7,7 +7,6 @@ class Scwrypts < Formula
 
   depends_on "awscli"
   depends_on "coreutils"
-  depends_on "docker"
   depends_on "ffmpeg"
   depends_on "findutils"
   depends_on "fzf"
@@ -29,6 +28,15 @@ class Scwrypts < Formula
   depends_on "yq"
 
   uses_from_macos "zsh"
+
+  def caveats
+    <<~EOS
+      This formula requires docker to be installed for full functionality.
+      You can install it with:
+        macos: brew install --cask docker
+        else:  brew install docker
+    EOS
+  end
 
   def install
     (share/"scwrypts").mkpath

--- a/Formula/scwrypts@4.3.rb
+++ b/Formula/scwrypts@4.3.rb
@@ -7,7 +7,6 @@ class ScwryptsAT43 < Formula
 
   depends_on "awscli"
   depends_on "coreutils"
-  depends_on "docker"
   depends_on "ffmpeg"
   depends_on "findutils"
   depends_on "fzf"
@@ -29,6 +28,15 @@ class ScwryptsAT43 < Formula
   depends_on "yq"
 
   uses_from_macos "zsh"
+
+  def caveats
+    <<~EOS
+      This formula requires docker to be installed for full functionality.
+      You can install it with:
+        macos: brew install --cask docker
+        else:  brew install docker
+    EOS
+  end
 
   def install
     (share/"scwrypts").mkpath

--- a/Formula/scwrypts@4.4.rb
+++ b/Formula/scwrypts@4.4.rb
@@ -7,7 +7,6 @@ class ScwryptsAT44 < Formula
 
   depends_on "awscli"
   depends_on "coreutils"
-  depends_on "docker"
   depends_on "ffmpeg"
   depends_on "findutils"
   depends_on "fzf"
@@ -29,6 +28,15 @@ class ScwryptsAT44 < Formula
   depends_on "yq"
 
   uses_from_macos "zsh"
+
+  def caveats
+    <<~EOS
+      This formula requires docker to be installed for full functionality.
+      You can install it with:
+        macos: brew install --cask docker
+        else:  brew install docker
+    EOS
+  end
 
   def install
     (share/"scwrypts").mkpath

--- a/Formula/scwrypts@4.rb
+++ b/Formula/scwrypts@4.rb
@@ -7,7 +7,6 @@ class ScwryptsAT4 < Formula
 
   depends_on "awscli"
   depends_on "coreutils"
-  depends_on "docker"
   depends_on "ffmpeg"
   depends_on "findutils"
   depends_on "fzf"
@@ -29,6 +28,15 @@ class ScwryptsAT4 < Formula
   depends_on "yq"
 
   uses_from_macos "zsh"
+
+  def caveats
+    <<~EOS
+      This formula requires docker to be installed for full functionality.
+      You can install it with:
+        macos: brew install --cask docker
+        else:  brew install docker
+    EOS
+  end
 
   def install
     (share/"scwrypts").mkpath


### PR DESCRIPTION
Sadly brew formulas can not depend on casks so we cant manage the docker dependency via brew.