### PR TITLE
Remove `node` as a required dependency

### DIFF
--- a/Formula/scwrypts.rb
+++ b/Formula/scwrypts.rb
@@ -19,7 +19,6 @@ class Scwrypts < Formula
   depends_on "libnotify"
   depends_on "libpq"
   depends_on "make"
-  depends_on "node"
   depends_on "pnpm"
   depends_on "redis"
   depends_on "ripgrep"
@@ -54,6 +53,11 @@ class Scwrypts < Formula
       You can install it with:
         macos: brew install --cask docker
         else:  brew install docker
+
+      This formula requires Node.js to be installed for extended functionality.
+      It is recommended to use a version manager like one of the following:
+        tj/n:  https://github.com/tj/n
+        nvm:   https://github.com/nvm-sh/nvm
 
       This formula requires texlive to be installed for extended functionality.
       You can install it with:

--- a/Formula/scwrypts@4.3.rb
+++ b/Formula/scwrypts@4.3.rb
@@ -19,7 +19,6 @@ class ScwryptsAT43 < Formula
   depends_on "libnotify"
   depends_on "libpq"
   depends_on "make"
-  depends_on "node"
   depends_on "pnpm"
   depends_on "redis"
   depends_on "ripgrep"
@@ -53,6 +52,11 @@ class ScwryptsAT43 < Formula
       You can install it with:
         macos: brew install --cask docker
         else:  brew install docker
+
+      This formula requires Node.js to be installed for extended functionality.
+      It is recommended to use a version manager like one of the following:
+        tj/n:  https://github.com/tj/n
+        nvm:   https://github.com/nvm-sh/nvm
 
       This formula requires texlive to be installed for extended functionality.
       You can install it with:

--- a/Formula/scwrypts@4.4.rb
+++ b/Formula/scwrypts@4.4.rb
@@ -19,7 +19,6 @@ class ScwryptsAT44 < Formula
   depends_on "libnotify"
   depends_on "libpq"
   depends_on "make"
-  depends_on "node"
   depends_on "pnpm"
   depends_on "redis"
   depends_on "ripgrep"
@@ -54,6 +53,11 @@ class ScwryptsAT44 < Formula
       You can install it with:
         macos: brew install --cask docker
         else:  brew install docker
+
+      This formula requires Node.js to be installed for extended functionality.
+      It is recommended to use a version manager like one of the following:
+        tj/n:  https://github.com/tj/n
+        nvm:   https://github.com/nvm-sh/nvm
 
       This formula requires texlive to be installed for extended functionality.
       You can install it with:

--- a/Formula/scwrypts@4.rb
+++ b/Formula/scwrypts@4.rb
@@ -19,7 +19,6 @@ class ScwryptsAT4 < Formula
   depends_on "libnotify"
   depends_on "libpq"
   depends_on "make"
-  depends_on "node"
   depends_on "pnpm"
   depends_on "redis"
   depends_on "ripgrep"
@@ -53,6 +52,11 @@ class ScwryptsAT4 < Formula
       You can install it with:
         macos: brew install --cask docker
         else:  brew install docker
+
+      This formula requires Node.js to be installed for extended functionality.
+      It is recommended to use a version manager like one of the following:
+        tj/n:  https://github.com/tj/n
+        nvm:   https://github.com/nvm-sh/nvm
 
       This formula requires texlive to be installed for extended functionality.
       You can install it with:


### PR DESCRIPTION
Installing the `node` homebrew target as a part of `scwrypts` appears to create conflicts with other node version management systems. Let's get it out to let people manage node environments better :+1: